### PR TITLE
Dictionary to store accession to entry mappings

### DIFF
--- a/scripts/PTM_predictor.py
+++ b/scripts/PTM_predictor.py
@@ -200,6 +200,7 @@ def main():
         #  if there's the third possibility (I don't know yet), we will print the Acc of that protein for a manual check.
         
         #Add a header for ProsightPD database search
+        f.write('<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n')
         f.write('<uniprot xmlns="http://uniprot.org/uniprot" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://uniprot.org/uniprot http://www.uniprot.org/support/docs/uniprot.xsd">\n')
   
         PathUniprotXML_sbjctAcceessionEntryDictionary = PTMp.Extract_access_entry_in_xml_dictionary(PathUniprotXML_sbjct)

--- a/scripts/PTM_predictor.py
+++ b/scripts/PTM_predictor.py
@@ -81,7 +81,6 @@ def main():
                              PathUniprotPTM=PathUniprotPTM_csv_sbjct,
                              PathUniprotXML=PathUniprotXML_sbjct)
 
-
     with open(PathShortFasta, "w") as short_sequence_fasta:
         PTM_csv = pd.read_csv(PathUniprotPTM_csv_query)
         if search_length%2 == 0:
@@ -167,9 +166,8 @@ def main():
     except:
         print("Seems like you don't have newly annotated PTMs")
 
-
-
     intermediate_csv_file = pd.read_csv(PathUniprotPTM_csv_predict, dtype={'Query_PTM_position': int, 'Query_start': int, 'Query_end': int, 'Sbjct_PTM_position': int})
+
     intermediate_csv_file_filtered = intermediate_csv_file.drop_duplicates(subset=['Sbjct_Accession_Number', 'Sbjct_PTM_position', 'Predicted_PTM'], keep='first').reset_index(drop=True)
 
     # simplify the information in the intermediate csv file by putting unique entries to a dictionary
@@ -190,7 +188,6 @@ def main():
         else:
             pass
 
-
     AccNO_csv_file = pd.read_csv(PathUniprotAccessionNumber_sbjct)
     with open(PathUniprotXML_xml_sbjct_modified, 'a') as f:
         # The is the main function that inserts new PTM sites into corresponding protein entry
@@ -205,12 +202,13 @@ def main():
         #Add a header for ProsightPD database search
         f.write('<uniprot xmlns="http://uniprot.org/uniprot" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://uniprot.org/uniprot http://www.uniprot.org/support/docs/uniprot.xsd">\n')
   
+        PathUniprotXML_sbjctAcceessionEntryDictionary = PTMp.Extract_access_entry_in_xml_dictionary(PathUniprotXML_sbjct)
+
         for i in range(0, AccNO_csv_file.shape[0]):
             Protein_Acc = AccNO_csv_file['Accession_Number'][i]
-            entry = PTMp.Extract_entry_in_xml_returnStyle(PathUniprotXML_sbjct, Protein_Acc)  # every protein will be extracted from the original xml no matter it has new PTM or not
+            entry = PathUniprotXML_sbjctAcceessionEntryDictionary[Protein_Acc]  # every protein will be extracted from the original xml no matter it has new PTM or not
             PTMpos = []
             if Protein_Acc in Dict_Acc_PTMpos_PTMdes.keys():
-
                 for ft in entry.findall('feature'):
                     if ft.attrib['type'] in FeatureType:
                         PTMpos.append(int(ft.findall('location')[0].find('position').attrib['position']))
@@ -245,6 +243,7 @@ def main():
                     print(PTMpos_predicted)
             else:
                 f.write(ET.tostring(entry, encoding="unicode"))  # No need to change anything, write as original
+
         #Add several lines at the end for ProsightPD database search
         f.writelines('<copyright> Copyrighted by the UniProt Consortium, see https://www.uniprot.org/terms Distributed under the Creative Commons Attribution (CC BY 4.0) License </copyright>\n')
         f.writelines('</uniprot>')

--- a/scripts/PTM_predictor_module.py
+++ b/scripts/PTM_predictor_module.py
@@ -132,6 +132,25 @@ def Extract_entry_in_xml_returnStyle(PathUniprotXML: str, ProteinID: str):
             break
     return elem
 
+def Extract_access_entry_in_xml_dictionary(PathUniprotXML: str):
+    """
+    This function is used to extract an entry for a given proteinID
+    :param PathUniprotXML:
+    :param ProteinID:
+    :return: the whole entry that contains all information for a given protein. The returned data type is NOT generator
+    """
+    import xml.etree.ElementTree as ET
+
+    PathUniprotXML_sbjctAcceessionEntryDictionary = {} 
+    
+    for event, elem in ET.iterparse(PathUniprotXML, events=("start", "end")):
+        elem.tag = NS_strip(elem.tag) # the uniprot address in each tag is removed
+        if event == "end" and elem.tag == 'entry':
+            if elem.find('accession').text not in PathUniprotXML_sbjctAcceessionEntryDictionary:
+                PathUniprotXML_sbjctAcceessionEntryDictionary[elem.find('accession').text] = elem
+              
+    return PathUniprotXML_sbjctAcceessionEntryDictionary
+
 
 def analyze_BLASTed_information_local_search(PathBLASTintermediate: str,
                                              Directory_intermediate_tobe_stored: str,
@@ -461,6 +480,10 @@ def create_blast_database(input_fasta, db_type="prot", db_name=None):
         ]
 
         # Run the makeblastdb command using subprocess
+
+        print("command")
+        print(command)
+
         subprocess.run(command, check=True)
         print(f"BLAST database '{db_name}' created successfully.")
 

--- a/scripts/PTM_predictor_module.py
+++ b/scripts/PTM_predictor_module.py
@@ -134,10 +134,9 @@ def Extract_entry_in_xml_returnStyle(PathUniprotXML: str, ProteinID: str):
 
 def Extract_access_entry_in_xml_dictionary(PathUniprotXML: str):
     """
-    This function is used to extract an entry for a given proteinID
+    This function is used to create a dictionary to mapping accessions to entries 
     :param PathUniprotXML:
-    :param ProteinID:
-    :return: the whole entry that contains all information for a given protein. The returned data type is NOT generator
+    :return: a dictionary to mapping accessions to entries
     """
     import xml.etree.ElementTree as ET
 


### PR DESCRIPTION
1. Update PTM_predictor.py to use dictionary of accession->entries to limit IO
2. Add method PTM_predictor_module.py to add function that creates  dictionary of accession to entry mappings.